### PR TITLE
Simplify wrapping logic by setting WRAP_<LANGUAGE> in each wrapper

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -59,7 +59,7 @@ jobs:
               SimpleITK_EXPLICIT_INSTANTIATION:BOOL=ON
               SimpleITK_USE_SYSTEM_SWIG:BOOL=OFF
           - os: mac-arm64
-            name: mac-arm64-python-elastix-python
+            name: mac-arm64-elastix-python
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             use-superbuild: false
@@ -67,7 +67,7 @@ jobs:
               WRAP_PYTHON:BOOL=ON
               SimpleITK_USE_ELASTIX:BOOL=ON
           - os: ubuntu-24.04
-            name: linux-x64-superbuild-elastix-python
+            name: linux-x64-superbuild-elastix-python-r
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             cmake_build_parallel_level: 6
@@ -104,7 +104,7 @@ jobs:
               CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
               CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
           - os: macos-15
-            name: macos-x86_64-python-java
+            name: macos-x86_64-python-r
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             cmake_osx_architectures: "x86_64"

--- a/CMake/sitkAddTest.cmake
+++ b/CMake/sitkAddTest.cmake
@@ -96,7 +96,7 @@ endfunction()
 # This is a function which set up the environment for executing python examples and tests
 #
 function(sitk_add_python_test name)
-  if(NOT WRAP_PYTHON AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_Python")
+  if(NOT WRAP_PYTHON)
     return()
   endif()
 
@@ -141,7 +141,7 @@ endfunction()
 # This is a function which set up the environment for executing python examples and tests
 #
 function(sitk_add_pytest_test name)
-  if(NOT WRAP_PYTHON AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_Python")
+  if(NOT WRAP_PYTHON)
     return()
   endif()
 
@@ -192,7 +192,7 @@ endfunction()
 # This is a function which set up the enviroment for executing lua examples and tests
 #
 function(sitk_add_lua_test name)
-  if(NOT WRAP_LUA AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_Lua")
+  if(NOT WRAP_LUA)
     return()
   endif()
 
@@ -235,7 +235,7 @@ endfunction()
 # This is a function which set up the enviroment for executing ruby examples and tests
 #
 function(sitk_add_ruby_test name)
-  if(NOT WRAP_RUBY AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_Ruby")
+  if(NOT WRAP_RUBY)
     return()
   endif()
 
@@ -278,7 +278,7 @@ endfunction()
 # This is a function which set up the enviroment for executing TCL examples and tests
 #
 function(sitk_add_tcl_test name)
-  if(NOT WRAP_TCL AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_Tcl")
+  if(NOT WRAP_TCL)
     return()
   endif()
 
@@ -313,7 +313,7 @@ endfunction()
 # This is a function which set up the enviroment for executing JAVA examples and tests
 #
 function(sitk_add_java_test name java_file)
-  if(NOT WRAP_JAVA AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_Java")
+  if(NOT WRAP_JAVA)
     return()
   endif()
 
@@ -383,7 +383,7 @@ endfunction()
 # This is a function which set up the enviroment for executing R examples and tests
 #
 function(sitk_add_r_test name)
-  if(NOT WRAP_R AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_R")
+  if(NOT WRAP_R)
     return()
   endif()
 
@@ -438,7 +438,7 @@ endfunction()
 # enviroment for executing CSharp examples and tests.
 #
 function(sitk_add_csharp_test name csharp_file)
-  if(NOT WRAP_CSHARP AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_CSharp")
+  if(NOT WRAP_CSHARP)
     return()
   endif()
 

--- a/CMake/sitkCMakeInit.cmake
+++ b/CMake/sitkCMakeInit.cmake
@@ -1,5 +1,5 @@
 set(SITK_CMAKE_MINIMUM_REQUIRED_VERSION "3.23.0")
-set(SITK_CMAKE_POLICY_VERSION "3.23")
+set(SITK_CMAKE_POLICY_VERSION "3.31.0")
 
 # cache_list_append( <cache list name> [<element> ...])
 #

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,14 +1,5 @@
-cmake_minimum_required(VERSION 3.16.3...3.20)
+cmake_minimum_required(VERSION 3.23.0...3.31.0)
 project(SimpleITKExamples)
-
-foreach(
-  p
-  CMP0156 # De-duplicate libraries on link lines based on linker capabilities.
-)
-  if(POLICY ${p})
-    cmake_policy(SET ${p} NEW)
-  endif()
-endforeach()
 
 if(NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK")
   find_package(SimpleITK REQUIRED)

--- a/Examples/CppCMake/Source/CMakeLists.txt
+++ b/Examples/CppCMake/Source/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.23.0...3.31.0)
 
 project(sitk_example)
 

--- a/Examples/Elastix/CMakeLists.txt
+++ b/Examples/Elastix/CMakeLists.txt
@@ -69,3 +69,123 @@ set_tests_properties(
     DEPENDS
       "Python.Example.Elastix"
 )
+
+# Java tests
+sitk_add_java_test(
+  Example.Elastix
+  "${CMAKE_CURRENT_SOURCE_DIR}/elx.java"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceBorder20.png}
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${CMAKE_CURRENT_SOURCE_DIR}/par0001.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/Java.Example.elx.nii
+  ${SimpleITK_TEST_OUTPUT_DIR}/Java.Example.elx.TransformParameters.txt
+)
+
+sitk_add_java_test(
+  Example.Transformix
+  "${CMAKE_CURRENT_SOURCE_DIR}/tfx.java"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${SimpleITK_TEST_OUTPUT_DIR}/Java.Example.elx.TransformParameters.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/Java.Example.tfx.nii
+  IMAGE_COMPARE
+    ${SimpleITK_TEST_OUTPUT_DIR}/Java.Example.elx.nii
+    ${SimpleITK_TEST_OUTPUT_DIR}/Java.Example.tfx.nii
+    40
+)
+
+set_tests_properties(
+  Java.Example.Transformix
+  PROPERTIES
+    DEPENDS
+      "Java.Example.Elastix"
+)
+
+# CSharp tests
+sitk_add_csharp_test(
+  Example.Elastix
+  "${CMAKE_CURRENT_SOURCE_DIR}/elx.cs"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceBorder20.png}
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${CMAKE_CURRENT_SOURCE_DIR}/par0001.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/CSharp.Example.elx.nii
+  ${SimpleITK_TEST_OUTPUT_DIR}/CSharp.Example.elx.TransformParameters.txt
+)
+
+sitk_add_csharp_test(
+  Example.Transformix
+  "${CMAKE_CURRENT_SOURCE_DIR}/tfx.cs"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${SimpleITK_TEST_OUTPUT_DIR}/CSharp.Example.elx.TransformParameters.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/CSharp.Example.tfx.nii
+  IMAGE_COMPARE
+    ${SimpleITK_TEST_OUTPUT_DIR}/CSharp.Example.elx.nii
+    ${SimpleITK_TEST_OUTPUT_DIR}/CSharp.Example.tfx.nii
+    40
+)
+
+set_tests_properties(
+  CSharp.Example.Transformix
+  PROPERTIES
+    DEPENDS
+      "CSharp.Example.Elastix"
+)
+
+# Lua tests
+sitk_add_lua_test(
+  Example.Elastix
+  "${CMAKE_CURRENT_SOURCE_DIR}/elx.lua"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceBorder20.png}
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${CMAKE_CURRENT_SOURCE_DIR}/par0001.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/Lua.Example.elx.nii
+  ${SimpleITK_TEST_OUTPUT_DIR}/Lua.Example.elx.TransformParameters.txt
+)
+
+sitk_add_lua_test(
+  Example.Transformix
+  "${CMAKE_CURRENT_SOURCE_DIR}/tfx.lua"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${SimpleITK_TEST_OUTPUT_DIR}/Lua.Example.elx.TransformParameters.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/Lua.Example.tfx.nii
+  IMAGE_COMPARE
+    ${SimpleITK_TEST_OUTPUT_DIR}/Lua.Example.elx.nii
+    ${SimpleITK_TEST_OUTPUT_DIR}/Lua.Example.tfx.nii
+    40
+)
+
+set_tests_properties(
+  Lua.Example.Transformix
+  PROPERTIES
+    DEPENDS
+      "Lua.Example.Elastix"
+)
+
+# R tests
+sitk_add_r_test(
+  Example.Elastix
+  "${CMAKE_CURRENT_SOURCE_DIR}/elx.R"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceBorder20.png}
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${CMAKE_CURRENT_SOURCE_DIR}/par0001.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/R.Example.elx.nii
+  ${SimpleITK_TEST_OUTPUT_DIR}/R.Example.elx.TransformParameters.txt
+)
+
+sitk_add_r_test(
+  Example.Transformix
+  "${CMAKE_CURRENT_SOURCE_DIR}/tfx.R"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${SimpleITK_TEST_OUTPUT_DIR}/R.Example.elx.TransformParameters.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/R.Example.tfx.nii
+  IMAGE_COMPARE
+    ${SimpleITK_TEST_OUTPUT_DIR}/R.Example.elx.nii
+    ${SimpleITK_TEST_OUTPUT_DIR}/R.Example.tfx.nii
+    40
+)
+
+set_tests_properties(
+  R.Example.Transformix
+  PROPERTIES
+    DEPENDS
+      "R.Example.Elastix"
+)

--- a/Examples/Elastix/CMakeLists.txt
+++ b/Examples/Elastix/CMakeLists.txt
@@ -63,12 +63,14 @@ sitk_add_python_test(
     40
 )
 
-set_tests_properties(
-  Python.Example.Transformix
-  PROPERTIES
-    DEPENDS
-      "Python.Example.Elastix"
-)
+if(WRAP_PYTHON)
+  set_tests_properties(
+    Python.Example.Transformix
+    PROPERTIES
+      DEPENDS
+        "Python.Example.Elastix"
+  )
+endif()
 
 # Java tests
 sitk_add_java_test(
@@ -93,12 +95,14 @@ sitk_add_java_test(
     40
 )
 
-set_tests_properties(
-  Java.Example.Transformix
-  PROPERTIES
-    DEPENDS
-      "Java.Example.Elastix"
-)
+if(WRAP_JAVA)
+  set_tests_properties(
+    Java.Example.Transformix
+    PROPERTIES
+      DEPENDS
+        "Java.Example.Elastix"
+  )
+endif()
 
 # CSharp tests
 sitk_add_csharp_test(
@@ -123,12 +127,14 @@ sitk_add_csharp_test(
     40
 )
 
-set_tests_properties(
-  CSharp.Example.Transformix
-  PROPERTIES
-    DEPENDS
-      "CSharp.Example.Elastix"
-)
+if(WRAP_CSHARP)
+  set_tests_properties(
+    CSharp.Example.Transformix
+    PROPERTIES
+      DEPENDS
+        "CSharp.Example.Elastix"
+  )
+endif()
 
 # Lua tests
 sitk_add_lua_test(
@@ -153,12 +159,14 @@ sitk_add_lua_test(
     40
 )
 
-set_tests_properties(
-  Lua.Example.Transformix
-  PROPERTIES
-    DEPENDS
-      "Lua.Example.Elastix"
-)
+if(WRAP_LUA)
+  set_tests_properties(
+    Lua.Example.Transformix
+    PROPERTIES
+      DEPENDS
+        "Lua.Example.Elastix"
+  )
+endif()
 
 # R tests
 sitk_add_r_test(
@@ -183,9 +191,11 @@ sitk_add_r_test(
     40
 )
 
-set_tests_properties(
-  R.Example.Transformix
-  PROPERTIES
-    DEPENDS
-      "R.Example.Elastix"
-)
+if(WRAP_R)
+  set_tests_properties(
+    R.Example.Transformix
+    PROPERTIES
+      DEPENDS
+        "R.Example.Elastix"
+  )
+endif()

--- a/Examples/Elastix/Documentation.rst
+++ b/Examples/Elastix/Documentation.rst
@@ -36,11 +36,29 @@ Registration (elx)
 
 .. tabs::
 
+  .. tab:: C#
+
+    .. literalinclude:: ../../Examples/Elastix/elx.cs
+       :language: c#
+       :lines: 18-
+
   .. tab:: C++
 
     .. literalinclude:: ../../Examples/Elastix/elx.cxx
        :language: c++
        :lines: 1-
+
+  .. tab:: Java
+
+    .. literalinclude:: ../../Examples/Elastix/elx.java
+       :language: java
+       :lines: 18-
+
+  .. tab:: Lua
+
+    .. literalinclude:: ../../Examples/Elastix/elx.lua
+       :language: lua
+       :lines: 18-
 
   .. tab:: Python
 
@@ -48,10 +66,22 @@ Registration (elx)
        :language: python
        :lines: 1-
 
+  .. tab:: R
+
+    .. literalinclude:: ../../Examples/Elastix/elx.R
+       :language: r
+       :lines: 18-
+
 Transformation (tfx)
 ^^^^^^^^^^^^^^^^^^^^
 
 .. tabs::
+
+  .. tab:: C#
+
+    .. literalinclude:: ../../Examples/Elastix/tfx.cs
+       :language: c#
+       :lines: 18-
 
   .. tab:: C++
 
@@ -59,11 +89,29 @@ Transformation (tfx)
        :language: c++
        :lines: 1-
 
+  .. tab:: Java
+
+    .. literalinclude:: ../../Examples/Elastix/tfx.java
+       :language: java
+       :lines: 18-
+
+  .. tab:: Lua
+
+    .. literalinclude:: ../../Examples/Elastix/tfx.lua
+       :language: lua
+       :lines: 18-
+
   .. tab:: Python
 
     .. literalinclude:: ../../Examples/Elastix/tfx.py
        :language: python
        :lines: 1-
+
+  .. tab:: R
+
+    .. literalinclude:: ../../Examples/Elastix/tfx.R
+       :language: r
+       :lines: 18-
 
 See Also
 --------

--- a/Examples/Elastix/elx.R
+++ b/Examples/Elastix/elx.R
@@ -1,0 +1,43 @@
+#=========================================================================
+#
+#  Copyright NumFOCUS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+
+library(SimpleITK)
+
+args <- commandArgs(TRUE)
+
+if (length(args) < 5) {
+    stop("Usage: elx <fixedImage> <movingImage> <parameterFile> <outputImage> <outputParameterFile>")
+}
+
+# Instantiate SimpleElastix
+elastixImageFilter <- ElastixImageFilter()
+
+# Read input
+elastixImageFilter$SetFixedImage(ReadImage(args[1]))
+elastixImageFilter$SetMovingImage(ReadImage(args[2]))
+elastixImageFilter$SetParameterMap(elastixImageFilter$ReadParameterFile(args[3]))
+elastixImageFilter$LogToConsoleOn()
+
+# Run registration
+output_image <- elastixImageFilter$Execute()
+
+# Write result image
+WriteImage(output_image, args[4])
+
+# Write parameter file. This example only supports one parameter map and one transform parameter map.
+elastixImageFilter$WriteParameterFile(elastixImageFilter$GetTransformParameterMap(0L), args[5])

--- a/Examples/Elastix/elx.cs
+++ b/Examples/Elastix/elx.cs
@@ -1,0 +1,53 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+using System;
+using itk.simple;
+
+namespace itk.simple.examples
+{
+    class Elastix
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 5)
+            {
+                Console.WriteLine("Usage: elx <fixedImage> <movingImage> <parameterFile> <outputImage> <outputParameterFile>");
+                return;
+            }
+
+            // Instantiate SimpleElastix
+            ElastixImageFilter elastixImageFilter = new ElastixImageFilter();
+
+            // Read input
+            elastixImageFilter.SetFixedImage(SimpleITK.ReadImage(args[0]));
+            elastixImageFilter.SetMovingImage(SimpleITK.ReadImage(args[1]));
+            elastixImageFilter.SetParameterMap(SimpleITK.ReadParameterFile(args[2]));
+            elastixImageFilter.LogToConsoleOn();
+
+            // Run registration
+            elastixImageFilter.Execute();
+
+            // Write result image
+            SimpleITK.WriteImage(elastixImageFilter.GetResultImage(), args[3]);
+
+            // Write parameter file. This example only supports one parameter map and one transform parameter map.
+            SimpleITK.WriteParameterFile(elastixImageFilter.GetTransformParameterMaps()[0], args[4]);
+        }
+    }
+}

--- a/Examples/Elastix/elx.java
+++ b/Examples/Elastix/elx.java
@@ -1,0 +1,46 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+import org.itk.simple.*;
+
+public class elx {
+    public static void main(String[] args) {
+        if (args.length < 5) {
+            System.out.println("Usage: elx <fixedImage> <movingImage> <parameterFile> <outputImage> <outputParameterFile>");
+            System.exit(1);
+        }
+
+        // Instantiate SimpleElastix
+        ElastixImageFilter elastixImageFilter = new ElastixImageFilter();
+
+        // Read input
+        elastixImageFilter.setFixedImage(SimpleITK.readImage(args[0]));
+        elastixImageFilter.setMovingImage(SimpleITK.readImage(args[1]));
+        elastixImageFilter.setParameterMap(SimpleITK.readParameterFile(args[2]));
+        elastixImageFilter.logToConsoleOn();
+
+        // Run registration
+        elastixImageFilter.execute();
+
+        // Write result image
+        SimpleITK.writeImage(elastixImageFilter.getResultImage(), args[3]);
+
+        // Write parameter file. This example only supports one parameter map and one transform parameter map.
+        SimpleITK.writeParameterFile(elastixImageFilter.getTransformParameterMaps().get(0), args[4]);
+    }
+}

--- a/Examples/Elastix/elx.lua
+++ b/Examples/Elastix/elx.lua
@@ -1,0 +1,43 @@
+--=========================================================================
+--
+--  Copyright NumFOCUS
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0.txt
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+--=========================================================================
+
+require "SimpleITK"
+
+if #arg < 5 then
+    print("Usage: elx <fixedImage> <movingImage> <parameterFile> <outputImage> <outputParameterFile>")
+    os.exit(1)
+end
+
+-- Instantiate SimpleElastix
+elastixImageFilter = SimpleITK.ElastixImageFilter()
+
+-- Read input
+elastixImageFilter:SetFixedImage(SimpleITK.ReadImage(arg[1]))
+elastixImageFilter:SetMovingImage(SimpleITK.ReadImage(arg[2]))
+elastixImageFilter:SetParameterMap(SimpleITK.ReadParameterFile(arg[3]))
+elastixImageFilter:LogToConsoleOn()
+
+-- Run registration
+elastixImageFilter:Execute()
+
+-- Write result image
+SimpleITK.WriteImage(elastixImageFilter:GetResultImage(), arg[4])
+
+-- Write parameter file. This example only supports one parameter map and one transform parameter map.
+parameterMaps = elastixImageFilter:GetTransformParameterMaps()
+SimpleITK.WriteParameterFile(parameterMaps[0], arg[5])

--- a/Examples/Elastix/tfx.R
+++ b/Examples/Elastix/tfx.R
@@ -1,0 +1,39 @@
+#=========================================================================
+#
+#  Copyright NumFOCUS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+
+library(SimpleITK)
+
+args <- commandArgs(TRUE)
+
+if (length(args) < 3) {
+    stop("Usage: tfx <inputImage> <parameterFile> <outputImage>")
+}
+
+# Instantiate transformix
+transformixImageFilter <- TransformixImageFilter()
+transformixImageFilter$LogToConsoleOn()
+
+# Read input
+transformixImageFilter$SetMovingImage(ReadImage(args[1]))
+transformixImageFilter$SetTransformParameterMap(transformixImageFilter$ReadParameterFile(args[2]))
+
+# Run warp
+resampled_image <- transformixImageFilter$Execute()
+
+# Write result image
+WriteImage(resampled_image, args[3])

--- a/Examples/Elastix/tfx.cs
+++ b/Examples/Elastix/tfx.cs
@@ -1,0 +1,49 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+using System;
+using itk.simple;
+
+namespace itk.simple.examples
+{
+    class Transformix
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 3)
+            {
+                Console.WriteLine("Usage: tfx <inputImage> <parameterFile> <outputImage>");
+                return;
+            }
+
+            // Instantiate transformix
+            TransformixImageFilter transformixImageFilter = new TransformixImageFilter();
+            transformixImageFilter.LogToConsoleOn();
+
+            // Read input
+            transformixImageFilter.SetMovingImage(SimpleITK.ReadImage(args[0]));
+            transformixImageFilter.SetTransformParameterMap(SimpleITK.ReadParameterFile(args[1]));
+
+            // Run warp
+            transformixImageFilter.Execute();
+
+            // Write result image
+            SimpleITK.WriteImage(transformixImageFilter.GetResultImage(), args[2]);
+        }
+    }
+}

--- a/Examples/Elastix/tfx.java
+++ b/Examples/Elastix/tfx.java
@@ -1,0 +1,42 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+import org.itk.simple.*;
+
+public class tfx {
+    public static void main(String[] args) {
+        if (args.length < 3) {
+            System.out.println("Usage: tfx <inputImage> <parameterFile> <outputImage>");
+            System.exit(1);
+        }
+
+        // Instantiate transformix
+        TransformixImageFilter transformixImageFilter = new TransformixImageFilter();
+        transformixImageFilter.logToConsoleOn();
+
+        // Read input
+        transformixImageFilter.setMovingImage(SimpleITK.readImage(args[0]));
+        transformixImageFilter.setTransformParameterMap(SimpleITK.readParameterFile(args[1]));
+
+        // Run warp
+        transformixImageFilter.execute();
+
+        // Write result image
+        SimpleITK.writeImage(transformixImageFilter.getResultImage(), args[2]);
+    }
+}

--- a/Examples/Elastix/tfx.lua
+++ b/Examples/Elastix/tfx.lua
@@ -1,0 +1,38 @@
+--=========================================================================
+--
+--  Copyright NumFOCUS
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0.txt
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+--=========================================================================
+
+require "SimpleITK"
+
+if #arg < 3 then
+    print("Usage: tfx <inputImage> <parameterFile> <outputImage>")
+    os.exit(1)
+end
+
+-- Instantiate transformix
+transformixImageFilter = SimpleITK.TransformixImageFilter()
+transformixImageFilter:LogToConsoleOn()
+
+-- Read input
+transformixImageFilter:SetMovingImage(SimpleITK.ReadImage(arg[1]))
+transformixImageFilter:SetTransformParameterMap(SimpleITK.ReadParameterFile(arg[2]))
+
+-- Run warp
+transformixImageFilter:Execute()
+
+-- Write result image
+SimpleITK.WriteImage(transformixImageFilter:GetResultImage(), arg[3])

--- a/SuperBuild/swig_configure_step.cmake.in
+++ b/SuperBuild/swig_configure_step.cmake.in
@@ -4,7 +4,7 @@
 # environment. If there is a problem with them in the future they can
 # be addressed in CMake with the same structure.
 
-cmake_minimum_required(VERSION 3.16.3...3.26.0)
+cmake_minimum_required(VERSION 3.23.0...3.31.0)
 
 set(ENV{CC} "@CMAKE_C_COMPILER_LAUNCHER@ @CMAKE_C_COMPILER@")
 set(ENV{CFLAGS} "@REQUIRED_C_FLAGS@ @CMAKE_C_FLAGS@ @CMAKE_C_FLAGS_RELEASE@")

--- a/Wrapping/CSharp/CMakeLists.txt
+++ b/Wrapping/CSharp/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_CSharp)
+set(WRAP_CSHARP ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/Wrapping/Java/CMakeLists.txt
+++ b/Wrapping/Java/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_Java)
+set(WRAP_JAVA ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/Wrapping/Lua/CMakeLists.txt
+++ b/Wrapping/Lua/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_Lua)
+set(WRAP_LUA ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_Python)
+set(WRAP_PYTHON ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/Wrapping/Python/scikit-build-Packaging.cmake
+++ b/Wrapping/Python/scikit-build-Packaging.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.26...3.31.0)
 
 project(SimpleITKInternalPythonPackage NONE)
 

--- a/Wrapping/R/CMakeLists.txt
+++ b/Wrapping/R/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_R)
+set(WRAP_R ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/Wrapping/Ruby/CMakeLists.txt
+++ b/Wrapping/Ruby/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_Ruby)
+set(WRAP_RUBY ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/Wrapping/Tcl/CMakeLists.txt
+++ b/Wrapping/Tcl/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_TCL)
+set(WRAP_TCL ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/docs/images/CMakeLists.txt
+++ b/docs/images/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3..3.30.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16.3..3.31.0 FATAL_ERROR)
 
 project(SimpleITKSphinx-Data LANGUAGES NONE)
 


### PR DESCRIPTION
Add `set(WRAP_<LANGUAGE> ON)` to all wrapper CMakeLists.txt files and simplify the conditional checks in `sitk_add_<language>_test` functions to only check `WRAP_<LANGUAGE>` instead of both `WRAP_<LANGUAGE>` and `CMAKE_PROJECT_NAME`.

This fixes test failures on the dashboard when a wrapping directory is built as a standalone project.